### PR TITLE
Tweak verbose output

### DIFF
--- a/Classes/Command/IndexCommand.php
+++ b/Classes/Command/IndexCommand.php
@@ -40,7 +40,13 @@ class IndexCommand extends Command
         $oneTaskFailed = false;
         foreach ($sites as $site) {
             if ($output->isVerbose()) {
-                $output->writeln(sprintf('Indexing %s (Root page %d)', $site->getDomain(), $site->getRootPageId()));
+                $output->writeln(
+                    sprintf(
+                        'Indexing %s (Root page %d)',
+                        $site->getTypo3SiteObject()->getBase(),
+                        $site->getRootPageId()
+                    )
+                );
             }
 
             $indexTask = GeneralUtility::makeInstance(IndexQueueWorkerTask::class);


### PR DESCRIPTION
We've got a lot of sites using the same host name but different paths.

So the verbosed output is pretty useless:

```
$ bin/typo3 solrcommands:index -vvv
Indexing www.exampe.org (Root page 9202)
Indexing www.exampe.org (Root page 7366)
Indexing www.exampe.org (Root page 7177)
Indexing www.exampe.org (Root page 12224)
...
````

With this patch it looks like this:

````
$ bin/typo3 solrcommands:index -vvv
Indexing http://www.exampe.org/site-1 (Root page 9202)
Indexing http://www.exampe.org/site-2 (Root page 7366)
Indexing http://www.exampe.org/site-3 (Root page 7177)
Indexing http://www.exampe.org:8000/site-4 (Root page 12224)
````